### PR TITLE
Fix issue with NULL root element on broken XML files

### DIFF
--- a/emf4cpp/ecorecpp/resource/XMLResource.cpp
+++ b/emf4cpp/ecorecpp/resource/XMLResource.cpp
@@ -217,6 +217,13 @@ void XMLResource::doLoad(
 	 * cross-document !
 	 */
 	::ecore::EObject_ptr root = handler.getRootElement();
+	if (!root) {
+		/* Input XML file could be broken/truncated. In this case getRootElement()
+		 * returns NULL.
+		 */
+		throw std::logic_error("No root element found");
+	}
+
 	root->_initialize();
 
 	getContents()->push_back(root);


### PR DESCRIPTION
When input XML file is broken or truncated there is no correct root element and handler.getRootElement() function returns NULL.
Function XMLResource::doLoad() is of type void so the easiest way here is to throw an exception.